### PR TITLE
Custom parcelname

### DIFF
--- a/PostnlApp.qml
+++ b/PostnlApp.qml
@@ -18,6 +18,7 @@ App {
 	property string timeStr
 	property string dateStr
 	property bool enableSystray
+	property bool enableUseCustomParcelName
 
 	property string postnlUserid
 	property string postnlPassword
@@ -28,6 +29,7 @@ App {
 	property string tileSender
 	property string tileDate
 	property string tileTime
+	property string tileParcelName
 
 	// user settings from config file
 
@@ -47,10 +49,15 @@ App {
 			} else {
 				enableSystray = false
 			}
-			postnlUserid = postnlSettingsJson['Userid'];		
+			if (postnlSettingsJson['UseCustomParcelName'] == "Yes") {
+				enableUseCustomParcelName = true
+			} else {
+				enableUseCustomParcelName = false
+			}
+			postnlUserid = postnlSettingsJson['Userid'];
 			postnlPassword = postnlSettingsJson['Password'];
-			if (postnlSettingsJson['UpdateFrequencyInMinutes']) postnlUpdateFrequencyInMinutes = postnlSettingsJson['UpdateFrequencyInMinutes'];		
-			if (postnlSettingsJson['ShowHistoryInMonths']) postnlShowHistoryInMonths = postnlSettingsJson['ShowHistoryInMonths'];		
+			if (postnlSettingsJson['UpdateFrequencyInMinutes']) postnlUpdateFrequencyInMinutes = postnlSettingsJson['UpdateFrequencyInMinutes'];
+			if (postnlSettingsJson['ShowHistoryInMonths']) postnlShowHistoryInMonths = postnlSettingsJson['ShowHistoryInMonths'];
 		} catch(e) {
 		}
 
@@ -72,7 +79,7 @@ App {
 	}
 
 	function saveSettings() {
-		
+
 		// save user settings
 
 		var tmpTrayIcon = "";
@@ -81,13 +88,21 @@ App {
 		} else {
 			tmpTrayIcon = "No";
 		}
+		var tmpCustomParcelName = "";
+		if (enableUseCustomParcelName == true) {
+			tmpCustomParcelName = "Yes";
+		} else {
+			tmpCustomParcelName = "No";
+		}
+
 
  		var tmpUserSettingsJson = {
 			"Userid" : postnlUserid,
 			"TrayIcon" : tmpTrayIcon,
 			"Password" : postnlPassword,
 			"UpdateFrequencyInMinutes" : postnlUpdateFrequencyInMinutes,
-			"ShowHistoryInMonths" : postnlShowHistoryInMonths
+			"ShowHistoryInMonths" : postnlShowHistoryInMonths,
+			"UseCustomParcelName": tmpCustomParcelName
 		}
 
   		var doc3 = new XMLHttpRequest();
@@ -110,8 +125,8 @@ App {
 		running: false
 		repeat: true
 		onTriggered: {
-			interval = postnlUpdateFrequencyInMinutes * 60000;	
-			postnlScreen.refreshScreen(); 
+			interval = postnlUpdateFrequencyInMinutes * 60000;
+			postnlScreen.refreshScreen();
 		}
 	}
 
@@ -122,7 +137,7 @@ App {
 		running: false
 		repeat: true
 		onTriggered: {	// request tsc script to retrieve postnl inbox
-			interval = postnlUpdateFrequencyInMinutes * 60000;	
+			interval = postnlUpdateFrequencyInMinutes * 60000;
  			var doc4 = new XMLHttpRequest();
   			doc4.open("PUT", "file:///tmp/tsc.command");
    			doc4.send("postnl");

--- a/PostnlConfigurationScreen.qml
+++ b/PostnlConfigurationScreen.qml
@@ -8,6 +8,7 @@ Screen {
 
 	onShown: {
 		enableSystrayToggle.isSwitchedOn = app.enableSystray;
+		enableUseCustomParcelNameToggle.isSwitchedOn = app.enableUseCustomParcelName;
 		postnlUseridLabel.inputText = app.postnlUserid;
 		postnlUpdateFrequencyInMinutesLabel.inputText = app.postnlUpdateFrequencyInMinutes;
 		postnlShowHistoryInMonthsLabel.inputText = app.postnlShowHistoryInMonths;
@@ -53,7 +54,7 @@ Screen {
 		if (text) {
 			app.postnlShowHistoryInMonths = text;
 			postnlShowHistoryInMonthsLabel.inputText = text;
-			app.postnlScreen.refreshScreen(); 
+			app.postnlScreen.refreshScreen();
 		}
 	}
 
@@ -254,6 +255,37 @@ Screen {
 			qnumKeyboard.open("Hoeveel maanden historie moet er getoond worden?", postnlShowHistoryInMonthsLabel.inputText, app.postnlShowHistoryInMonths, 1 , savePostnlShowHistoryInMonths, validatePostnlShowHistoryInMonths);
 			qnumKeyboard.maxTextLength = 2;
 			qnumKeyboard.state = "num_integer_clear_backspace";
+		}
+	}
+
+	Text {
+		id: enableUseCustomParcelNameLabel
+		width: postnlShowHistoryInMonthsLabel.width
+		height: isNxt ? 45 : 36
+		text: "Toon custom parcel name"
+		font.family: qfont.semiBold.name
+		font.pixelSize: isNxt ? 25 : 20
+		anchors {
+			left: postnlShowHistoryInMonthsLabel.left
+			leftMargin: isNxt ? 10 : 8
+			top: postnlShowHistoryInMonthsLabel.bottom
+			topMargin: 6
+		}
+	}
+
+	OnOffToggle {
+		id: enableUseCustomParcelNameToggle
+		height: isNxt ? 45 : 36
+		anchors.right: postnlShowHistoryInMonthsButton.right
+		anchors.leftMargin: 10
+		anchors.top: enableUseCustomParcelNameLabel.top
+		leftIsSwitchedOn: false
+		onSelectedChangedByUser: {
+			if (isSwitchedOn) {
+				app.enableUseCustomParcelName = true;
+			} else {
+				app.enableUseCustomParcelName = false;
+			}
 		}
 	}
 }

--- a/PostnlScreen.qml
+++ b/PostnlScreen.qml
@@ -72,6 +72,7 @@ Screen {
 		app.tileTime =  "";
 		app.tileBarcode = "Geen pakketten verwacht";
 		app.tileSender = "";
+		app.tilePackageName = "";
 
 			// read inbox
 
@@ -91,6 +92,10 @@ Screen {
 				if (postNLData['receiver'][0]['sender']['companyName']) {
 					app.tileSender = postNLData['receiver'][0]['sender']['companyName'];
 				}
+				if (postNLData['receiver'][0]['trackedShipment']['title']) {
+					app.tilePackageName = postNLData['receiver'][0]['trackedShipment']['title'];
+				}
+
 			}
 		}
 
@@ -193,7 +198,7 @@ Screen {
 		StandardButton {
 			id: showParcelType
 			height: isNxt ? 40 : 32
-			text: (showReceived) ? "Ontvangen " : "Verstuurde " 
+			text: (showReceived) ? "Ontvangen " : "Verstuurde "
 			fontPixelSize: isNxt ? 25 : 20
 			color: colors.background
 			anchors {

--- a/PostnlScreen.qml
+++ b/PostnlScreen.qml
@@ -72,7 +72,7 @@ Screen {
 		app.tileTime =  "";
 		app.tileBarcode = "Geen pakketten verwacht";
 		app.tileSender = "";
-		app.tilePackageName = "";
+		app.tileParcelName = "";
 
 			// read inbox
 
@@ -92,8 +92,8 @@ Screen {
 				if (postNLData['receiver'][0]['sender']['companyName']) {
 					app.tileSender = postNLData['receiver'][0]['sender']['companyName'];
 				}
-				if (postNLData['receiver'][0]['trackedShipment']['title']) {
-					app.tilePackageName = postNLData['receiver'][0]['trackedShipment']['title'];
+				if (app.enableUseCustomParcelName == true && postNLData['receiver'][0]['trackedShipment']['title']) {
+					app.tileParcelName = postNLData['receiver'][0]['trackedShipment']['title'];
 				}
 
 			}

--- a/PostnlTile.qml
+++ b/PostnlTile.qml
@@ -11,7 +11,7 @@ Tile {
 
 	Text {
 		id: txtBarcode
-		text: app.tileBarcode
+		text: (app.tilePackageName.length > 2) ? app.tilePackageName.substring(0, 15) : app.tileBarcode
 		color: (typeof dimmableColors !== 'undefined') ? dimmableColors.clockTileColor : colors.clockTileColor
 		anchors {
 			baseline: parent.top

--- a/PostnlTile.qml
+++ b/PostnlTile.qml
@@ -11,7 +11,7 @@ Tile {
 
 	Text {
 		id: txtBarcode
-		text: (app.tilePackageName.length > 2) ? app.tilePackageName.substring(0, 15) : app.tileBarcode
+		text: (app.tileParcelName.length > 0) ? app.tileParcelName.substring(0, 25) : app.tileBarcode
 		color: (typeof dimmableColors !== 'undefined') ? dimmableColors.clockTileColor : colors.clockTileColor
 		anchors {
 			baseline: parent.top


### PR DESCRIPTION
The PostNL app provides the functionality to use a custom name for an incoming parcel. 
I've added some code to display this custom name instead of the barcode when a customer has provided this custom parcel name in the PostNL app (and therefore in the POSTNL-Inbox.json)